### PR TITLE
Add Function Globals Support

### DIFF
--- a/aarch64/isa/bl.go
+++ b/aarch64/isa/bl.go
@@ -1,0 +1,79 @@
+package aarch64isa
+
+import (
+	"alon.kr/x/aarch64codegen/instructions"
+	"alon.kr/x/list"
+	aarch64codegen "alon.kr/x/usm/aarch64/codegen"
+	aarch64translation "alon.kr/x/usm/aarch64/translation"
+	"alon.kr/x/usm/core"
+	"alon.kr/x/usm/gen"
+)
+
+type Bl struct {
+	Target *gen.FunctionInfo
+}
+
+func (b Bl) Operator() string {
+	return "bl"
+}
+
+func (b Bl) PossibleNextSteps() (gen.StepInfo, core.ResultList) {
+	// TODO: add an analysis to check if the target function is a no-return
+	// function.
+	return gen.StepInfo{PossibleContinue: true}, core.ResultList{}
+}
+
+func (b Bl) Generate(
+	ctx *aarch64codegen.InstructionCodegenContext,
+) (instructions.Instruction, core.ResultList) {
+	targetOffset := ctx.FunctionOffsets[b.Target]
+	currentOffset := ctx.FunctionOffsets[ctx.FunctionInfo] + ctx.InstructionOffsetInFunction
+	offset, err := aarch64translation.Uint64DiffToOffset26Align4(targetOffset, currentOffset)
+
+	if err != nil {
+		return nil, list.FromSingle(core.Result{
+			{
+				Type:     core.ErrorResult,
+				Message:  "Invalid branch offset (arbitrary large offsets are not yet supported)",
+				Location: ctx.Declaration,
+			},
+			{
+				Type:    core.DebugResult,
+				Message: err.Error(),
+			},
+		})
+	}
+
+	return instructions.BL(offset), core.ResultList{}
+}
+
+type BlDefinition struct{}
+
+func (BlDefinition) BuildInstruction(
+	info *gen.InstructionInfo,
+) (gen.BaseInstruction, core.ResultList) {
+	results := core.ResultList{}
+
+	curResults := aarch64translation.AssertArgumentsExactly(info, 1)
+	results.Extend(&curResults)
+
+	curResults = aarch64translation.AssertTargetsExactly(info, 0)
+	results.Extend(&curResults)
+
+	if !results.IsEmpty() {
+		return nil, results
+	}
+
+	target, curResults := aarch64translation.ArgumentToFunctionInfo(info.Arguments[0])
+	results.Extend(&curResults)
+
+	if !results.IsEmpty() {
+		return nil, results
+	}
+
+	return Bl{Target: target}, core.ResultList{}
+}
+
+func NewBlInstructionDefinition() gen.InstructionDefinition {
+	return BlDefinition{}
+}

--- a/aarch64/managers/context.go
+++ b/aarch64/managers/context.go
@@ -11,6 +11,7 @@ func NewManagerCreators() gen.ManagerCreators {
 		RegisterManagerCreator: NewRegisterManager,
 		LabelManagerCreator:    gen.NewLabelMap,
 		TypeManagerCreator:     NewTypeManager,
+		GlobalManagerCreator:   gen.NewGlobalMap,
 	}
 }
 

--- a/aarch64/managers/instructions.go
+++ b/aarch64/managers/instructions.go
@@ -21,6 +21,7 @@ func NewInstructionManager() gen.InstructionManager {
 
 			// Control flow
 			{Key: "b", Value: aarch64isa.NewBranchInstructionDefinition()},
+			{Key: "bl", Value: aarch64isa.NewBlInstructionDefinition()},
 			{Key: "ret", Value: aarch64isa.NewRetInstructionDefinition()},
 
 			// Conditional branches

--- a/aarch64/translation/arguments.go
+++ b/aarch64/translation/arguments.go
@@ -119,9 +119,9 @@ func ArgumentToAarch64GPorSPRegister(
 	return RegisterToAarch64GPOrSPRegister(register.Register)
 }
 
-func ArgumentToBigInt(
+func ArgumentToImmediateInfo(
 	argument gen.ArgumentInfo,
-) (*big.Int, core.ResultList) {
+) (*gen.ImmediateInfo, core.ResultList) {
 	imm, ok := argument.(*gen.ImmediateInfo)
 	if !ok {
 		return nil, list.FromSingle(core.Result{
@@ -133,7 +133,7 @@ func ArgumentToBigInt(
 		})
 	}
 
-	return imm.Value, core.ResultList{}
+	return imm, core.ResultList{}
 }
 
 func ArgumentToAarch64Immediate12(
@@ -141,17 +141,17 @@ func ArgumentToAarch64Immediate12(
 ) (immediates.Immediate12, core.ResultList) {
 	// TODO: remove code duplication with other immediate types.
 
-	results := AssertIntegerTypeOfSize(*argument.GetType(), big.NewInt(12))
+	info, results := ArgumentToImmediateInfo(argument)
 	if !results.IsEmpty() {
 		return 0, results
 	}
 
-	bigInt, results := ArgumentToBigInt(argument)
+	results = AssertIntegerTypeOfSize(info.Type, big.NewInt(12))
 	if !results.IsEmpty() {
 		return 0, results
 	}
 
-	return BigIntToAarch64Immediate12(argument.Declaration(), bigInt)
+	return BigIntToAarch64Immediate12(argument.Declaration(), info.Value)
 }
 
 func BigIntToAarch64Immediate12(
@@ -183,17 +183,17 @@ fail:
 func ArgumentToAarch64Immediate16(
 	argument gen.ArgumentInfo,
 ) (immediates.Immediate16, core.ResultList) {
-	results := AssertIntegerTypeOfSize(*argument.GetType(), big.NewInt(16))
+	info, results := ArgumentToImmediateInfo(argument)
 	if !results.IsEmpty() {
 		return 0, results
 	}
 
-	bigInt, results := ArgumentToBigInt(argument)
+	results = AssertIntegerTypeOfSize(info.Type, big.NewInt(16))
 	if !results.IsEmpty() {
 		return 0, results
 	}
 
-	return BigIntToAarch64Immediate16(argument.Declaration(), bigInt)
+	return BigIntToAarch64Immediate16(argument.Declaration(), info.Value)
 }
 
 func BigIntToAarch64Immediate16(
@@ -283,12 +283,12 @@ func BigIntToAarch64MovShift(
 func ArgumentToAarch64MovShift(
 	argument gen.ArgumentInfo,
 ) (instructions.MovShift, core.ResultList) {
-	bigInt, results := ArgumentToBigInt(argument)
+	info, results := ArgumentToImmediateInfo(argument)
 	if !results.IsEmpty() {
 		return 0, results
 	}
 
-	return BigIntToAarch64MovShift(argument.Declaration(), bigInt)
+	return BigIntToAarch64MovShift(argument.Declaration(), info.Value)
 }
 
 func ArgumentToLabelInfo(argument gen.ArgumentInfo) (*gen.LabelInfo, core.ResultList) {

--- a/aarch64/translation/arguments.go
+++ b/aarch64/translation/arguments.go
@@ -305,3 +305,31 @@ func ArgumentToLabelInfo(argument gen.ArgumentInfo) (*gen.LabelInfo, core.Result
 
 	return label.Label, core.ResultList{}
 }
+
+func ArgumentToFunctionInfo(
+	argument gen.ArgumentInfo,
+) (*gen.FunctionInfo, core.ResultList) {
+	globalArg, ok := argument.(*gen.GlobalArgumentInfo)
+	if !ok {
+		return nil, list.FromSingle(core.Result{
+			{
+				Type:     core.ErrorResult,
+				Message:  "Expected global argument",
+				Location: argument.Declaration(),
+			},
+		})
+	}
+
+	info, ok := globalArg.GlobalInfo.(*gen.FunctionGlobalInfo)
+	if !ok {
+		return nil, list.FromSingle(core.Result{
+			{
+				Type:     core.ErrorResult,
+				Message:  "Expected function global argument",
+				Location: argument.Declaration(),
+			},
+		})
+	}
+
+	return info.FunctionInfo, core.ResultList{}
+}

--- a/examples/aarch64/bl-chain.usm
+++ b/examples/aarch64/bl-chain.usm
@@ -1,0 +1,13 @@
+func @foo {
+    bl @bar
+    ret
+}
+
+func @bar {
+    bl @baz
+    ret
+}
+
+func @baz {
+    ret
+}

--- a/examples/aarch64/for-loop.usm
+++ b/examples/aarch64/for-loop.usm
@@ -8,5 +8,5 @@ func @main {
     %x1 = add %x1 $12 #1
     b .loop
 .end
-    RET
+    ret
 }

--- a/gen/argument_generator.go
+++ b/gen/argument_generator.go
@@ -10,6 +10,7 @@ type ArgumentGenerator struct {
 	RegisterArgumentGenerator  InstructionContextGenerator[parse.RegisterNode, ArgumentInfo]
 	ImmediateArgumentGenerator InstructionContextGenerator[parse.ImmediateNode, ArgumentInfo]
 	LabelArgumentGenerator     InstructionContextGenerator[parse.LabelNode, ArgumentInfo]
+	GlobalArgumentGenerator    InstructionContextGenerator[parse.GlobalNode, ArgumentInfo]
 }
 
 func NewArgumentGenerator() InstructionContextGenerator[parse.ArgumentNode, ArgumentInfo] {
@@ -18,6 +19,7 @@ func NewArgumentGenerator() InstructionContextGenerator[parse.ArgumentNode, Argu
 			RegisterArgumentGenerator:  NewRegisterArgumentGenerator(),
 			ImmediateArgumentGenerator: NewImmediateArgumentGenerator(),
 			LabelArgumentGenerator:     NewLabelArgumentGenerator(),
+			GlobalArgumentGenerator:    NewGlobalArgumentGenerator(),
 		},
 	)
 }
@@ -33,6 +35,8 @@ func (g *ArgumentGenerator) Generate(
 		return g.ImmediateArgumentGenerator.Generate(ctx, typedNode)
 	case parse.LabelNode:
 		return g.LabelArgumentGenerator.Generate(ctx, typedNode)
+	case parse.GlobalNode:
+		return g.GlobalArgumentGenerator.Generate(ctx, typedNode)
 	default:
 		v := node.View()
 		return nil, list.FromSingle(core.Result{{

--- a/gen/argument_info.go
+++ b/gen/argument_info.go
@@ -3,11 +3,6 @@ package gen
 import "alon.kr/x/usm/core"
 
 type ArgumentInfo interface {
-	// A pointer to the ReferencedTypeInfo instance that corresponds to the
-	// type of the argument. Nil if the argument does not have a type (for
-	// example, a label).
-	GetType() *ReferencedTypeInfo
-
 	// The location where the argument appears in the source code.
 	Declaration() *core.UnmanagedSourceView
 

--- a/gen/function_generator.go
+++ b/gen/function_generator.go
@@ -343,12 +343,13 @@ func (g *FunctionGenerator) Generate(
 	name := ViewToSourceString(funcCtx.FileGenerationContext, node.Signature.Identifier)
 
 	function := &FunctionInfo{
-		Name:       name,
-		EntryBlock: nil, // will be defined later.
-		Registers:  funcCtx.Registers,
-		Labels:     funcCtx.Labels,
-		Parameters: parameters,
-		Targets:    targets,
+		Name:        name,
+		Declaration: &node.UnmanagedSourceView,
+		EntryBlock:  nil, // will be defined later.
+		Registers:   funcCtx.Registers,
+		Labels:      funcCtx.Labels,
+		Parameters:  parameters,
+		Targets:     targets,
 	}
 
 	instructions, results := g.generateInstructions(funcCtx, node.Instructions.Nodes)

--- a/gen/function_generator_test.go
+++ b/gen/function_generator_test.go
@@ -1,7 +1,6 @@
 package gen_test
 
 import (
-	"math/big"
 	"testing"
 
 	"alon.kr/x/usm/core"
@@ -26,16 +25,13 @@ func generateFunctionFromSource(
 	node, result := parse.NewFunctionParser().Parse(&tknView)
 	assert.Nil(t, result)
 
-	intType := gen.NewNamedTypeInfo("$32", big.NewInt(32), nil)
+	ctx := testGenerationContext.NewFileGenerationContext(sourceView.Ctx())
 
-	ctx := &gen.FileGenerationContext{
-		GenerationContext: &testGenerationContext,
-		SourceContext:     sourceView.Ctx(),
-		Types:             &TypeMap{intType.Name: intType},
-	}
+	funcGlobalGen := gen.NewFunctionGlobalGenerator()
+	funcGlobalGen.Generate(ctx, node)
 
-	generator := gen.NewFunctionGenerator()
-	return generator.Generate(ctx, node)
+	funcGen := gen.NewFunctionGenerator()
+	return funcGen.Generate(ctx, node)
 }
 
 func TestSimpleFunctionGeneration(t *testing.T) {

--- a/gen/function_global_generator.go
+++ b/gen/function_global_generator.go
@@ -1,0 +1,33 @@
+package gen
+
+import (
+	"alon.kr/x/usm/core"
+	"alon.kr/x/usm/parse"
+)
+
+type FunctionGlobalGenerator struct{}
+
+func NewFunctionGlobalGenerator() FileContextGenerator[parse.FunctionNode, GlobalInfo] {
+	return &FunctionGlobalGenerator{}
+}
+
+func (f *FunctionGlobalGenerator) Generate(
+	ctx *FileGenerationContext,
+	node parse.FunctionNode,
+) (GlobalInfo, core.ResultList) {
+	info := &FunctionInfo{
+		Name:        ViewToSourceString(ctx, node.Signature.Identifier),
+		Declaration: &node.UnmanagedSourceView,
+	}
+
+	global := &FunctionGlobalInfo{
+		FunctionInfo: info,
+	}
+
+	results := ctx.Globals.NewGlobal(global)
+	if !results.IsEmpty() {
+		return nil, results
+	}
+
+	return global, results
+}

--- a/gen/function_info.go
+++ b/gen/function_info.go
@@ -1,7 +1,11 @@
 package gen
 
+import "alon.kr/x/usm/core"
+
 type FunctionInfo struct {
-	Name       string
+	Name        string
+	Declaration *core.UnmanagedSourceView
+
 	EntryBlock *BasicBlockInfo
 	Registers  RegisterManager
 	Labels     LabelManager

--- a/gen/generator.go
+++ b/gen/generator.go
@@ -13,6 +13,7 @@ type ManagerCreators struct {
 	RegisterManagerCreator func(*FileGenerationContext) RegisterManager
 	LabelManagerCreator    func(*FileGenerationContext) LabelManager
 	TypeManagerCreator     func(*GenerationContext) TypeManager
+	GlobalManagerCreator   func(*GenerationContext) GlobalManager
 }
 
 // This structure is the most broad level of generation context.
@@ -45,6 +46,7 @@ func (ctx *GenerationContext) NewFileGenerationContext(
 		GenerationContext: ctx,
 		SourceContext:     source,
 		Types:             ctx.TypeManagerCreator(ctx),
+		Globals:           ctx.GlobalManagerCreator(ctx),
 	}
 }
 
@@ -59,7 +61,9 @@ type FileGenerationContext struct {
 	// new type definitions.
 	Types TypeManager
 
-	// TODO: add globals, variables, constants.
+	// A type manager that contains all declared and defines globals in the file.
+	// This includes function definitions and "extern" declarations.
+	Globals GlobalManager
 }
 
 func (ctx *FileGenerationContext) NewFunctionGenerationContext() *FunctionGenerationContext {

--- a/gen/global_argument.go
+++ b/gen/global_argument.go
@@ -1,0 +1,17 @@
+package gen
+
+import "alon.kr/x/usm/core"
+
+type GlobalArgumentInfo struct {
+	GlobalInfo
+
+	declaration *core.UnmanagedSourceView
+}
+
+func (g *GlobalArgumentInfo) Declaration() *core.UnmanagedSourceView {
+	return g.declaration
+}
+
+func (g *GlobalArgumentInfo) String() string {
+	return g.GlobalInfo.Name()
+}

--- a/gen/global_argument_generator.go
+++ b/gen/global_argument_generator.go
@@ -1,0 +1,41 @@
+package gen
+
+import (
+	"alon.kr/x/list"
+	"alon.kr/x/usm/core"
+	"alon.kr/x/usm/parse"
+)
+
+type GlobalArgumentGenerator struct{}
+
+func NewGlobalArgumentGenerator() InstructionContextGenerator[parse.GlobalNode, ArgumentInfo] {
+	return InstructionContextGenerator[parse.GlobalNode, ArgumentInfo](
+		&GlobalArgumentGenerator{},
+	)
+}
+
+func (g *GlobalArgumentGenerator) Generate(
+	ctx *InstructionGenerationContext,
+	node parse.GlobalNode,
+) (ArgumentInfo, core.ResultList) {
+	name := NodeToSourceString(ctx.FileGenerationContext, node)
+	global := ctx.Globals.GetGlobal(name)
+
+	if global == nil {
+		v := node.View()
+		return nil, list.FromSingle(core.Result{
+			{
+				Type:     core.ErrorResult,
+				Message:  "Undefined global",
+				Location: &v,
+			},
+		})
+	}
+
+	argument := &GlobalArgumentInfo{
+		GlobalInfo:  global,
+		declaration: &node.UnmanagedSourceView,
+	}
+
+	return argument, core.ResultList{}
+}

--- a/gen/global_function_info.go
+++ b/gen/global_function_info.go
@@ -1,0 +1,25 @@
+package gen
+
+import "alon.kr/x/usm/core"
+
+type FunctionGlobalInfo struct {
+	*FunctionInfo
+}
+
+func NewFunctionGlobalInfo(functionInfo *FunctionInfo) GlobalInfo {
+	return &FunctionGlobalInfo{
+		FunctionInfo: functionInfo,
+	}
+}
+
+func (f *FunctionGlobalInfo) Name() string {
+	return f.FunctionInfo.Name
+}
+
+func (f *FunctionGlobalInfo) Declaration() *core.UnmanagedSourceView {
+	return f.FunctionInfo.Declaration
+}
+
+func (f *FunctionGlobalInfo) IsDefined() bool {
+	return f.FunctionInfo.EntryBlock != nil
+}

--- a/gen/global_info.go
+++ b/gen/global_info.go
@@ -1,0 +1,13 @@
+package gen
+
+import "alon.kr/x/usm/core"
+
+type GlobalInfo interface {
+	Name() string
+	Declaration() *core.UnmanagedSourceView
+
+	// IsDefined returns true if the global variable is defined in the current
+	// file. If false, it means that the global is externally defined and
+	// expected to be linked in a later stage.
+	IsDefined() bool
+}

--- a/gen/global_manager.go
+++ b/gen/global_manager.go
@@ -1,0 +1,9 @@
+package gen
+
+import "alon.kr/x/usm/core"
+
+type GlobalManager interface {
+	GetGlobal(name string) GlobalInfo
+	NewGlobal(GlobalInfo) core.ResultList
+	GetAllGlobals() []GlobalInfo
+}

--- a/gen/global_map.go
+++ b/gen/global_map.go
@@ -7,7 +7,7 @@ import (
 type GlobalMap map[string]GlobalInfo
 
 func NewGlobalMap(*GenerationContext) GlobalManager {
-	return &GlobalMap{}
+	return &GlobalMap(make(map[string]GlobalInfo))
 }
 
 func (m *GlobalMap) GetGlobal(name string) GlobalInfo {

--- a/gen/global_map.go
+++ b/gen/global_map.go
@@ -7,7 +7,7 @@ import (
 type GlobalMap map[string]GlobalInfo
 
 func NewGlobalMap(*GenerationContext) GlobalManager {
-	return &GlobalMap(make(map[string]GlobalInfo))
+	return &GlobalMap{}
 }
 
 func (m *GlobalMap) GetGlobal(name string) GlobalInfo {

--- a/gen/global_map.go
+++ b/gen/global_map.go
@@ -1,0 +1,29 @@
+package gen
+
+import (
+	"alon.kr/x/usm/core"
+)
+
+type GlobalMap map[string]GlobalInfo
+
+func NewGlobalMap(*GenerationContext) GlobalManager {
+	return &GlobalMap{}
+}
+
+func (m *GlobalMap) GetGlobal(name string) GlobalInfo {
+	return (*m)[name]
+}
+
+func (m *GlobalMap) NewGlobal(global GlobalInfo) core.ResultList {
+	name := global.Name()
+	(*m)[name] = global
+	return core.ResultList{}
+}
+
+func (m *GlobalMap) GetAllGlobals() []GlobalInfo {
+	globals := make([]GlobalInfo, 0, len(*m))
+	for _, global := range *m {
+		globals = append(globals, global)
+	}
+	return globals
+}

--- a/gen/global_map_test.go
+++ b/gen/global_map_test.go
@@ -1,0 +1,22 @@
+package gen
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobalMap(t *testing.T) {
+	gm := NewGlobalMap(nil)
+	assert.Empty(t, gm.GetAllGlobals())
+
+	info := &FunctionInfo{Name: "foo"}
+	global := NewFunctionGlobalInfo(info)
+
+	results := gm.NewGlobal(global)
+	assert.True(t, results.IsEmpty())
+
+	gotGlobal := gm.GetGlobal("foo")
+	assert.Equal(t, global, gotGlobal)
+	assert.Equal(t, info.Name, gotGlobal.Name())
+}

--- a/gen/immediate_generator_test.go
+++ b/gen/immediate_generator_test.go
@@ -39,11 +39,10 @@ func TestImmediateValueArgument(t *testing.T) {
 
 	generator := gen.NewImmediateArgumentGenerator()
 	argument, results := generator.Generate(&ctx, node)
-
 	assert.True(t, results.IsEmpty())
-	assert.Equal(t, intType, argument.GetType().Base)
 
 	immediateArgument, ok := argument.(*gen.ImmediateInfo)
 	assert.True(t, ok)
+	assert.Equal(t, intType, immediateArgument.Type.Base)
 	assert.Zero(t, immediateArgument.Value.Cmp(big.NewInt(1337)))
 }

--- a/gen/immediate_info.go
+++ b/gen/immediate_info.go
@@ -13,10 +13,6 @@ type ImmediateInfo struct {
 	// TODO: more complex and complete representation of immediate structs.
 }
 
-func (i *ImmediateInfo) GetType() *ReferencedTypeInfo {
-	return &i.Type
-}
-
 func (i *ImmediateInfo) Declaration() *core.UnmanagedSourceView {
 	return &i.declaration
 }

--- a/gen/label_argument.go
+++ b/gen/label_argument.go
@@ -23,10 +23,6 @@ func NewLabelArgumentInfo(
 	}
 }
 
-func (i *LabelArgumentInfo) GetType() *ReferencedTypeInfo {
-	return nil // Label argument does not have a type
-}
-
 func (i *LabelArgumentInfo) Declaration() *core.UnmanagedSourceView {
 	return i.declaration
 }

--- a/gen/register_argument.go
+++ b/gen/register_argument.go
@@ -23,10 +23,6 @@ func (i *RegisterArgumentInfo) String() string {
 	return i.Register.String()
 }
 
-func (i *RegisterArgumentInfo) GetType() *ReferencedTypeInfo {
-	return &i.Register.Type
-}
-
 func (i *RegisterArgumentInfo) Declaration() *core.UnmanagedSourceView {
 	return i.declaration
 }

--- a/usm64/managers/context.go
+++ b/usm64/managers/context.go
@@ -11,6 +11,7 @@ func NewManagerCreators() gen.ManagerCreators {
 		RegisterManagerCreator: NewRegisterManager,
 		LabelManagerCreator:    gen.NewLabelMap,
 		TypeManagerCreator:     NewTypeManager,
+		GlobalManagerCreator:   gen.NewGlobalMap,
 	}
 }
 


### PR DESCRIPTION
This PR adds support for `@global` arguments, and in particular, adds support for global function references that are defined in the same file, to the `aarch64` isa.