### PR TITLE
Add codegen tests for sub, adds, subs, movz, and ret instructions

### DIFF
--- a/aarch64/isa/adds_test.go
+++ b/aarch64/isa/adds_test.go
@@ -1,0 +1,59 @@
+package aarch64isa_test
+
+import (
+	"fmt"
+	"testing"
+
+	"alon.kr/x/aarch64codegen/immediates"
+	"alon.kr/x/aarch64codegen/instructions"
+	"alon.kr/x/aarch64codegen/registers"
+	aarch64isa "alon.kr/x/usm/aarch64/isa"
+)
+
+func TestAddsExpectedCodegen(t *testing.T) {
+	def := aarch64isa.NewAdds()
+
+	testCases := []struct {
+		src      string
+		expected instructions.Instruction
+	}{
+		{
+			"%x0 = adds %x1 %x2\n",
+			instructions.NewAddsShiftedRegister(
+				registers.GPRegisterX0,
+				registers.GPRegisterX1,
+				registers.GPRegisterX2,
+			),
+		},
+		{
+			"%xzr = adds %xzr %xzr\n",
+			instructions.NewAddsShiftedRegister(
+				registers.GPRegisterXZR,
+				registers.GPRegisterXZR,
+				registers.GPRegisterXZR,
+			),
+		},
+		{
+			"%x0 = adds %x1 $12 #1234\n",
+			instructions.NewAddsImmediate(
+				registers.GPRegisterX0,
+				registers.GPorSPRegisterX1,
+				immediates.Immediate12(1234),
+			),
+		},
+		{
+			"%xzr = adds %sp $12 #0\n",
+			instructions.NewAddsImmediate(
+				registers.GPRegisterXZR,
+				registers.GPorSPRegisterSP,
+				immediates.Immediate12(0),
+			),
+		},
+	}
+
+	for idx, testCase := range testCases {
+		t.Run(fmt.Sprint(idx), func(t *testing.T) {
+			assertExpectedCodegen(t, def, testCase.expected, testCase.src)
+		})
+	}
+}

--- a/aarch64/isa/movz_test.go
+++ b/aarch64/isa/movz_test.go
@@ -1,0 +1,59 @@
+package aarch64isa_test
+
+import (
+	"fmt"
+	"testing"
+
+	"alon.kr/x/aarch64codegen/immediates"
+	"alon.kr/x/aarch64codegen/instructions"
+	"alon.kr/x/aarch64codegen/registers"
+	aarch64isa "alon.kr/x/usm/aarch64/isa"
+)
+
+func TestMovzExpectedCodegen(t *testing.T) {
+	def := aarch64isa.NewMovz()
+
+	testCases := []struct {
+		src      string
+		expected instructions.Instruction
+	}{
+		{
+			"%x0 = movz $16 #0xffff\n",
+			instructions.MOVZ(
+				registers.GPRegisterX0,
+				immediates.Immediate16(0xffff),
+				instructions.MovShift0,
+			),
+		},
+		{
+			"%x1 = movz $16 #0\n",
+			instructions.MOVZ(
+				registers.GPRegisterX1,
+				immediates.Immediate16(0),
+				instructions.MovShift0,
+			),
+		},
+		{
+			"%x2 = movz $16 #0x1234 $8 #16\n",
+			instructions.MOVZ(
+				registers.GPRegisterX2,
+				immediates.Immediate16(0x1234),
+				instructions.MovShift16,
+			),
+		},
+		{
+			"%xzr = movz $16 #0xabcd $8 #32\n",
+			instructions.MOVZ(
+				registers.GPRegisterXZR,
+				immediates.Immediate16(0xabcd),
+				instructions.MovShift32,
+			),
+		},
+	}
+
+	for idx, testCase := range testCases {
+		t.Run(fmt.Sprint(idx), func(t *testing.T) {
+			assertExpectedCodegen(t, def, testCase.expected, testCase.src)
+		})
+	}
+}

--- a/aarch64/isa/ret_test.go
+++ b/aarch64/isa/ret_test.go
@@ -1,0 +1,38 @@
+package aarch64isa_test
+
+import (
+	"fmt"
+	"testing"
+
+	"alon.kr/x/aarch64codegen/instructions"
+	"alon.kr/x/aarch64codegen/registers"
+	aarch64isa "alon.kr/x/usm/aarch64/isa"
+)
+
+func TestRetExpectedCodegen(t *testing.T) {
+	def := aarch64isa.NewRet()
+
+	testCases := []struct {
+		src      string
+		expected instructions.Instruction
+	}{
+		{
+			"ret\n",
+			instructions.RET(registers.GPRegisterX30),
+		},
+		{
+			"ret %x30\n",
+			instructions.RET(registers.GPRegisterX30),
+		},
+		{
+			"ret %x0\n",
+			instructions.RET(registers.GPRegisterX0),
+		},
+	}
+
+	for idx, testCase := range testCases {
+		t.Run(fmt.Sprint(idx), func(t *testing.T) {
+			assertExpectedCodegen(t, def, testCase.expected, testCase.src)
+		})
+	}
+}

--- a/aarch64/isa/sub_test.go
+++ b/aarch64/isa/sub_test.go
@@ -1,0 +1,59 @@
+package aarch64isa_test
+
+import (
+	"fmt"
+	"testing"
+
+	"alon.kr/x/aarch64codegen/immediates"
+	"alon.kr/x/aarch64codegen/instructions"
+	"alon.kr/x/aarch64codegen/registers"
+	aarch64isa "alon.kr/x/usm/aarch64/isa"
+)
+
+func TestSubExpectedCodegen(t *testing.T) {
+	def := aarch64isa.NewSub()
+
+	testCases := []struct {
+		src      string
+		expected instructions.Instruction
+	}{
+		{
+			"%x0 = sub %x1 %x2\n",
+			instructions.NewSubShiftedRegister(
+				registers.GPRegisterX0,
+				registers.GPRegisterX1,
+				registers.GPRegisterX2,
+			),
+		},
+		{
+			"%xzr = sub %xzr %xzr\n",
+			instructions.NewSubShiftedRegister(
+				registers.GPRegisterXZR,
+				registers.GPRegisterXZR,
+				registers.GPRegisterXZR,
+			),
+		},
+		{
+			"%x0 = sub %x1 $12 #1234\n",
+			instructions.NewSubImmediate(
+				registers.GPRegisterX0,
+				registers.GPorSPRegisterX1,
+				immediates.Immediate12(1234),
+			),
+		},
+		{
+			"%xzr = sub %sp $12 #0\n",
+			instructions.NewSubImmediate(
+				registers.GPRegisterXZR,
+				registers.GPorSPRegisterSP,
+				immediates.Immediate12(0),
+			),
+		},
+	}
+
+	for idx, testCase := range testCases {
+		t.Run(fmt.Sprint(idx), func(t *testing.T) {
+			assertExpectedCodegen(t, def, testCase.expected, testCase.src)
+		})
+	}
+}

--- a/aarch64/isa/subs_test.go
+++ b/aarch64/isa/subs_test.go
@@ -1,0 +1,59 @@
+package aarch64isa_test
+
+import (
+	"fmt"
+	"testing"
+
+	"alon.kr/x/aarch64codegen/immediates"
+	"alon.kr/x/aarch64codegen/instructions"
+	"alon.kr/x/aarch64codegen/registers"
+	aarch64isa "alon.kr/x/usm/aarch64/isa"
+)
+
+func TestSubsExpectedCodegen(t *testing.T) {
+	def := aarch64isa.NewSubs()
+
+	testCases := []struct {
+		src      string
+		expected instructions.Instruction
+	}{
+		{
+			"%xzr = subs %x0 %x1\n",
+			instructions.NewSubsShiftedRegister(
+				registers.GPRegisterXZR,
+				registers.GPRegisterX0,
+				registers.GPRegisterX1,
+			),
+		},
+		{
+			"%x0 = subs %x1 %x2\n",
+			instructions.NewSubsShiftedRegister(
+				registers.GPRegisterX0,
+				registers.GPRegisterX1,
+				registers.GPRegisterX2,
+			),
+		},
+		{
+			"%xzr = subs %x0 $12 #1234\n",
+			instructions.NewSubsImmediate(
+				registers.GPRegisterXZR,
+				registers.GPorSPRegisterX0,
+				immediates.Immediate12(1234),
+			),
+		},
+		{
+			"%x0 = subs %sp $12 #0\n",
+			instructions.NewSubsImmediate(
+				registers.GPRegisterX0,
+				registers.GPorSPRegisterSP,
+				immediates.Immediate12(0),
+			),
+		},
+	}
+
+	for idx, testCase := range testCases {
+		t.Run(fmt.Sprint(idx), func(t *testing.T) {
+			assertExpectedCodegen(t, def, testCase.expected, testCase.src)
+		})
+	}
+}


### PR DESCRIPTION
Adds test coverage for five untested aarch64 ISA instruction files
following the existing pattern in add_test.go. Increases overall project
coverage from 36% to 44.4% and aarch64/isa package coverage from 8.9%
to 38.2%.

https://claude.ai/code/session_01UoXAJxWfNBdf5RcZEhescU